### PR TITLE
🦙 Spark 3.1.2 🦙

### DIFF
--- a/notebook-image/elyra-spark3/Dockerfile
+++ b/notebook-image/elyra-spark3/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/thoth-station/s2i-lab-elyra:v0.0.12
 
 ARG PKG_ROOT=/opt/spark
-ARG SPARK_VERSION=3.0.1
+ARG SPARK_VERSION=3.1.2
 
 USER root
 

--- a/notebook-image/elyra-spark3/Dockerfile.312
+++ b/notebook-image/elyra-spark3/Dockerfile.312
@@ -1,7 +1,7 @@
 FROM quay.io/thoth-station/s2i-lab-elyra:v0.0.12
 
 ARG PKG_ROOT=/opt/spark
-ARG SPARK_VERSION=3.0.1
+ARG SPARK_VERSION=3.1.2
 
 USER root
 


### PR DESCRIPTION
elyra & spark 3.1.2 image

also this links to/with the cekit built image for spark cluster deployment:
https://github.com/eformat/openshift-spark-1/commit/808e682cf0597e63e747f67dbafb6808d3828b7c 

image here:
quay.io/eformat/openshift-spark:latest